### PR TITLE
FIX: Expand tilda on data dir or it fails to run.

### DIFF
--- a/task-git.sh
+++ b/task-git.sh
@@ -6,6 +6,7 @@ TASK_COMMAND="task ${@}"
 DATA_RC=$(task _show | grep data.location)
 DATA=(${DATA_RC//=/ })
 DATA_DIR=${DATA[1]}
+DATA_DIR="${DATA_DIR/#\~/$HOME}"
 if [ ! -d "$DATA_DIR" ]; then
   echo 'Could not load data directory!'
   exit 1


### PR DESCRIPTION
Avoided using `eval` for tilda expansion as per suggestion on
https://stackoverflow.com/questions/3963716/how-to-manually-expand-a-special-variable-ex-tilde-in-bash/27485157#27485157